### PR TITLE
Add a configuration to launch PowerShell from code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,6 +9,13 @@
             "request": "attach",
             "name": "Attach by Process ID",
             "processId": "${command:PickProcess}"
+        },
+        {
+            "name": "PowerShell: Launch Current File",
+            "type": "PowerShell",
+            "request": "launch",
+            "script": "${file}",
+            "cwd": "${file}"
         }
     ]
 }


### PR DESCRIPTION
Add a vscode configuration to launch PowerShell files. You still need to select it from the debug pane, but this allows us to debug the extension or the ps1 files if needed.

I imagine this can be removed if we ever get a debug handler in [n]vim, but for now this was something that I needed a few weeks ago, so thought I would throw it up here for others.