### PR TITLE
Get powershell path in a better way

### DIFF
--- a/downloadPSES.ps1
+++ b/downloadPSES.ps1
@@ -4,7 +4,7 @@ param(
 )
 if (!$IsCoreCLR) {
     # We only need to do this in Windows PowerShell.
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
 }
 
 # Fail on anything

--- a/downloadSnippets.ps1
+++ b/downloadSnippets.ps1
@@ -3,7 +3,7 @@
 Write-Host Starting download of Snippets from vscode-powershell
 if (!$IsCoreCLR) {
     # We only need to do this in Windows PowerShell.
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
 }
 
 # Fail on anything

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,69 +1,37 @@
 {
     "name": "coc-powershell",
-    "version": "0.0.21",
+    "version": "0.0.22",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
         "@chemzqm/neovim": {
             "version": "5.1.9",
-            "resolved": "https://registry.npmjs.org/@chemzqm/neovim/-/neovim-5.1.9.tgz",
-            "integrity": "sha512-lV60tnl2jcJZj3Hb+IDg6uz2zsjsB2hIGAiaW5a452SlVeLmuUoDsy2WaqRbFqcIHZKG5GTP3ttnOlB+ltHWhg==",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/@chemzqm/neovim/-/@chemzqm/neovim-5.1.9.tgz",
+            "integrity": "sha1-nh0HCI5iJAIulDpUz9Dwn6owANo=",
             "dev": true,
             "requires": {
                 "msgpack-lite": "^0.1.26"
             }
         },
-        "@types/events": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-            "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
-        },
-        "@types/extract-zip": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/@types/extract-zip/-/extract-zip-1.6.2.tgz",
-            "integrity": "sha1-XH60QcQRNhZ6QriLZAUeYmDCnoY="
-        },
         "@types/follow-redirects": {
             "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@types/follow-redirects/-/follow-redirects-1.8.0.tgz",
-            "integrity": "sha512-xFTn5zG9x9clBXhiTlmVrHDkBPEiYGmAoKr9dQdy8lZUoXcr01xVhXQW/MmUiYZZu2c1SpOleM90B7mN+CuXhA==",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/@types/follow-redirects/-/@types/follow-redirects-1.8.0.tgz",
+            "integrity": "sha1-pvRyIlRq7lnZoJquoRRrwaZybsc=",
+            "dev": true,
             "requires": {
                 "@types/node": "*"
             }
-        },
-        "@types/glob": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-            "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
-            "requires": {
-                "@types/events": "*",
-                "@types/minimatch": "*",
-                "@types/node": "*"
-            }
-        },
-        "@types/minimatch": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-            "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
         },
         "@types/node": {
-            "version": "10.14.10",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.10.tgz",
-            "integrity": "sha512-V8wj+w2YMNvGuhgl/MA5fmTxgjmVHVoasfIaxMMZJV6Y8Kk+Ydpi1z2whoShDCJ2BuNVoqH/h1hrygnBxkrw/Q=="
-        },
-        "@types/rimraf": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-2.0.2.tgz",
-            "integrity": "sha512-Hm/bnWq0TCy7jmjeN5bKYij9vw5GrDFWME4IuxV08278NtU/VdGbzsBohcCUJ7+QMqmUq5hpRKB39HeQWJjztQ==",
-            "requires": {
-                "@types/glob": "*",
-                "@types/node": "*"
-            }
+            "version": "10.17.19",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/@types/node/-/@types/node-10.17.19.tgz",
+            "integrity": "sha1-HTHd1VA9uir3qQGq/vM5LklVYg4=",
+            "dev": true
         },
         "await-semaphore": {
             "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/await-semaphore/-/await-semaphore-0.1.3.tgz",
-            "integrity": "sha512-d1W2aNSYcz/sxYO4pMGX9vq65qOTu0P800epMud+6cYYX0QcT7zyqcxec3VWzpgvdXo57UWmVbZpLMjX2m1I7Q==",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/await-semaphore/-/await-semaphore-0.1.3.tgz",
+            "integrity": "sha1-K4gBjMjCjgYWeuHN/wJQTx+WiNM=",
             "dev": true
         },
         "balanced-match": {
@@ -81,65 +49,68 @@
             }
         },
         "bser": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.0.tgz",
-            "integrity": "sha512-8zsjWrQkkBoLK6uxASk1nJ2SKv97ltiGDo6A3wA0/yRPz+CwmEyDo0hUrhIuukG2JHpAl3bvFIixw2/3Hi0DOg==",
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/bser/-/bser-2.1.1.tgz",
+            "integrity": "sha1-5nh9og7OnQeZhTPP2d5vXDj0vAU=",
             "dev": true,
             "requires": {
                 "node-int64": "^0.4.0"
             }
         },
+        "buffer-crc32": {
+            "version": "0.2.13",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+        },
         "buffer-from": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8="
         },
         "chownr": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-            "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
+            "version": "1.1.4",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha1-b8nXtC0ypYNZYzdmbn0ICE2izGs=",
             "dev": true
         },
         "coc-utils": {
-            "version": "0.0.10",
-            "resolved": "https://registry.npmjs.org/coc-utils/-/coc-utils-0.0.10.tgz",
-            "integrity": "sha512-Up+faM0wJQ6ePl7oWRIYvHspwWdtTOunwYlJXzRZIBolJHvwX8uJ0P+sasvKepf4Sp+WG473QBdi9cq/N8BcaQ==",
+            "version": "0.0.12",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/coc-utils/-/coc-utils-0.0.12.tgz",
+            "integrity": "sha1-r4pqLA75oniriz0RUU0f3YnKo8g=",
             "requires": {
-                "@types/extract-zip": "^1.6.2",
-                "@types/follow-redirects": "^1.7.0",
-                "@types/rimraf": "^2.0.2",
                 "extract-zip": "^1.6.7",
                 "follow-redirects": "^1.7.0",
                 "rimraf": "^2.6.3",
+                "tunnel": "0.0.6",
                 "vscode-jsonrpc": ">=4.0.0",
                 "vscode-languageserver-protocol": ">=3.14.0"
             },
             "dependencies": {
                 "vscode-jsonrpc": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
-                    "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg=="
+                    "version": "5.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
+                    "integrity": "sha1-m6ucMw2J9D/IwehwK1w24FigF5Q="
                 },
                 "vscode-languageserver-protocol": {
-                    "version": "3.14.1",
-                    "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz",
-                    "integrity": "sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==",
+                    "version": "3.15.3",
+                    "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz",
+                    "integrity": "sha1-P6mgcC10LPeIPLYYKmIS/NCh2Ls=",
                     "requires": {
-                        "vscode-jsonrpc": "^4.0.0",
-                        "vscode-languageserver-types": "3.14.0"
+                        "vscode-jsonrpc": "^5.0.1",
+                        "vscode-languageserver-types": "3.15.1"
                     }
                 },
                 "vscode-languageserver-types": {
-                    "version": "3.14.0",
-                    "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
-                    "integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A=="
+                    "version": "3.15.1",
+                    "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
+                    "integrity": "sha1-F75x140vYjbUFPAAHOHvTSPmtt4="
                 }
             }
         },
         "coc.nvim": {
-            "version": "0.0.74",
-            "resolved": "https://registry.npmjs.org/coc.nvim/-/coc.nvim-0.0.74.tgz",
-            "integrity": "sha512-9U8l2lXjnOM7lgSSOLpLkdvUeh1UAxAKfeVLMZgXRdfuSZJF82GWX2326dbQR30s9icLpSLBsWbcC6KGxW/kRQ==",
+            "version": "0.0.77",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/coc.nvim/-/coc.nvim-0.0.77.tgz",
+            "integrity": "sha1-U37kP7D0tA5sB60jmjBnfidKmtk=",
             "dev": true,
             "requires": {
                 "@chemzqm/neovim": "5.1.9",
@@ -160,28 +131,19 @@
                 "rimraf": "^3.0.0",
                 "semver": "^6.3.0",
                 "tar": "^4.4.10",
-                "tslib": "^1.10.0",
+                "tslib": "^1.11.0",
                 "tunnel": "^0.0.6",
                 "uuid": "^3.3.3",
-                "vscode-languageserver-protocol": "3.15.0-next.6",
-                "vscode-languageserver-types": "3.15.0-next.2",
+                "vscode-languageserver-protocol": "^3.15.3",
+                "vscode-languageserver-types": "^3.15.1",
                 "vscode-uri": "^2.0.3",
                 "which": "^1.3.1"
             },
             "dependencies": {
-                "follow-redirects": {
-                    "version": "1.9.0",
-                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.9.0.tgz",
-                    "integrity": "sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==",
-                    "dev": true,
-                    "requires": {
-                        "debug": "^3.0.0"
-                    }
-                },
                 "rimraf": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
-                    "integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
+                    "version": "3.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/rimraf/-/rimraf-3.0.2.tgz",
+                    "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
                     "dev": true,
                     "requires": {
                         "glob": "^7.1.3"
@@ -196,8 +158,8 @@
         },
         "concat-stream": {
             "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/concat-stream/-/concat-stream-1.6.2.tgz",
+            "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
             "requires": {
                 "buffer-from": "^1.0.0",
                 "inherits": "^2.0.3",
@@ -207,19 +169,19 @@
         },
         "core-util-is": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "date-format": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
-            "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/date-format/-/date-format-2.1.0.tgz",
+            "integrity": "sha1-MdW16iEc9f12TNOLr50DPffhJc8=",
             "dev": true
         },
         "debounce": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.0.tgz",
-            "integrity": "sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/debounce/-/debounce-1.2.0.tgz",
+            "integrity": "sha1-RKVAq8DqmUMBjcDqqVzOh/Zc0TE=",
             "dev": true
         },
         "debug": {
@@ -232,83 +194,96 @@
         },
         "deep-extend": {
             "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw=",
             "dev": true
         },
         "event-lite": {
             "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/event-lite/-/event-lite-0.1.2.tgz",
-            "integrity": "sha512-HnSYx1BsJ87/p6swwzv+2v6B4X+uxUteoDfRxsAb1S1BePzQqOLevVmkdA15GHJVd9A9Ok6wygUR18Hu0YeV9g==",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/event-lite/-/event-lite-0.1.2.tgz",
+            "integrity": "sha1-g4o+D93e+MyQ8SgAbI5VpOTkwRs=",
             "dev": true
         },
         "extract-zip": {
-            "version": "1.6.7",
-            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
-            "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+            "version": "1.7.0",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/extract-zip/-/extract-zip-1.7.0.tgz",
+            "integrity": "sha1-VWzDrp339FLEk6DPtRzDAneUCSc=",
             "requires": {
-                "concat-stream": "1.6.2",
-                "debug": "2.6.9",
-                "mkdirp": "0.5.1",
-                "yauzl": "2.4.1"
+                "concat-stream": "^1.6.2",
+                "debug": "^2.6.9",
+                "mkdirp": "^0.5.4",
+                "yauzl": "^2.10.0"
             },
             "dependencies": {
                 "debug": {
                     "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
                     "requires": {
                         "ms": "2.0.0"
                     }
                 },
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI="
+                },
+                "mkdirp": {
+                    "version": "0.5.5",
+                    "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/mkdirp/-/mkdirp-0.5.5.tgz",
+                    "integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
+                    "requires": {
+                        "minimist": "^1.2.5"
+                    }
+                },
                 "ms": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/ms/-/ms-2.0.0.tgz",
                     "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
             }
         },
         "fast-diff": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-            "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/fast-diff/-/fast-diff-1.2.0.tgz",
+            "integrity": "sha1-c+4RmC2Gyq95WYKNUZz+kn+sXwM=",
             "dev": true
         },
         "fb-watchman": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
-            "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/fb-watchman/-/fb-watchman-2.0.1.tgz",
+            "integrity": "sha1-/IT7OdJwnPP/bXQ3BhV7tXCKioU=",
             "dev": true,
             "requires": {
-                "bser": "^2.0.0"
+                "bser": "2.1.1"
             }
         },
         "fd-slicer": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-            "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/fd-slicer/-/fd-slicer-1.1.0.tgz",
+            "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
             "requires": {
                 "pend": "~1.2.0"
             }
         },
         "flatted": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
-            "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+            "version": "2.0.2",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/flatted/-/flatted-2.0.2.tgz",
+            "integrity": "sha1-RXWyHivO50NKqb5mL0t7X5wrUTg=",
             "dev": true
         },
         "follow-redirects": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
-            "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
+            "version": "1.11.0",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/follow-redirects/-/follow-redirects-1.11.0.tgz",
+            "integrity": "sha1-r6FPCLoSpSljFA/kMhJliJe8Dss=",
             "requires": {
-                "debug": "^3.2.6"
+                "debug": "^3.0.0"
             }
         },
         "fs-extra": {
             "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.2.0",
@@ -318,8 +293,8 @@
         },
         "fs-minipass": {
             "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-            "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/fs-minipass/-/fs-minipass-1.2.7.tgz",
+            "integrity": "sha1-zP+FcIQef+QmVpPaiJNsVa7X98c=",
             "dev": true,
             "requires": {
                 "minipass": "^2.6.0"
@@ -344,15 +319,15 @@
             }
         },
         "graceful-fs": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-            "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+            "version": "4.2.3",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/graceful-fs/-/graceful-fs-4.2.3.tgz",
+            "integrity": "sha1-ShL/G2A3bvCYYsIJPt2Qgyi+hCM=",
             "dev": true
         },
         "ieee754": {
             "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/ieee754/-/ieee754-1.1.13.tgz",
+            "integrity": "sha1-7BaFWOlaoYH9h9N/VcMrvLZwi4Q=",
             "dev": true
         },
         "inflight": {
@@ -371,13 +346,13 @@
         },
         "ini": {
             "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/ini/-/ini-1.3.5.tgz",
+            "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
             "dev": true
         },
         "int64-buffer": {
             "version": "0.1.10",
-            "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/int64-buffer/-/int64-buffer-0.1.10.tgz",
             "integrity": "sha1-J3siiofZWtd30HwTgyAiQGpHNCM=",
             "dev": true
         },
@@ -388,13 +363,13 @@
         },
         "isexe": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
             "dev": true
         },
         "isuri": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/isuri/-/isuri-2.0.3.tgz",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/isuri/-/isuri-2.0.3.tgz",
             "integrity": "sha1-NDcSHbL+Za8LoIC34ahjb2MsypE=",
             "dev": true,
             "requires": {
@@ -402,14 +377,14 @@
             }
         },
         "jsonc-parser": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.1.1.tgz",
-            "integrity": "sha512-VC0CjnWJylKB1iov4u76/W/5Ef0ydDkjtYWxoZ9t3HdWlSnZQwZL5MgFikaB/EtQ4RmMEw3tmQzuYnZA2/Ja1g==",
+            "version": "2.2.1",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
+            "integrity": "sha1-23PNWdeMzihyMZlGayoD0b4d8rw=",
             "dev": true
         },
         "jsonfile": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "dev": true,
             "requires": {
@@ -417,22 +392,22 @@
             }
         },
         "log4js": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/log4js/-/log4js-5.2.0.tgz",
-            "integrity": "sha512-WrKU7iRszr4gqxFstD2cCMewE22vpwXe3ieXzMdX+47ftWJDnfmFllb3Bm/B7NdK/Fk42/u5XM6Evr/U00PLjw==",
+            "version": "5.3.0",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/log4js/-/log4js-5.3.0.tgz",
+            "integrity": "sha1-fkP6SfUWwtEcca4o7d/9UI7vK6g=",
             "dev": true,
             "requires": {
                 "date-format": "^2.1.0",
                 "debug": "^4.1.1",
                 "flatted": "^2.0.1",
                 "rfdc": "^1.1.4",
-                "streamroller": "^2.2.0"
+                "streamroller": "^2.2.2"
             },
             "dependencies": {
                 "debug": {
                     "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
                     "dev": true,
                     "requires": {
                         "ms": "^2.1.1"
@@ -449,14 +424,15 @@
             }
         },
         "minimist": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+            "version": "1.2.5",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
+            "dev": true
         },
         "minipass": {
             "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-            "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/minipass/-/minipass-2.9.0.tgz",
+            "integrity": "sha1-5xN2Ln0+Mv7YAxFc+T4EvKn8yaY=",
             "dev": true,
             "requires": {
                 "safe-buffer": "^5.1.2",
@@ -465,19 +441,20 @@
         },
         "minizlib": {
             "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-            "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/minizlib/-/minizlib-1.3.3.tgz",
+            "integrity": "sha1-IpDeloGKNMKVUcio0wEha9Zahh0=",
             "dev": true,
             "requires": {
                 "minipass": "^2.9.0"
             }
         },
         "mkdirp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "version": "0.5.5",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/mkdirp/-/mkdirp-0.5.5.tgz",
+            "integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
+            "dev": true,
             "requires": {
-                "minimist": "0.0.8"
+                "minimist": "^1.2.5"
             }
         },
         "ms": {
@@ -487,7 +464,7 @@
         },
         "msgpack-lite": {
             "version": "0.1.26",
-            "resolved": "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/msgpack-lite/-/msgpack-lite-0.1.26.tgz",
             "integrity": "sha1-3TxQsm8FnyXn7e42REGDWOKprYk=",
             "dev": true,
             "requires": {
@@ -499,7 +476,7 @@
         },
         "mv": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/mv/-/mv-2.1.1.tgz",
             "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
             "dev": true,
             "requires": {
@@ -510,7 +487,7 @@
             "dependencies": {
                 "glob": {
                     "version": "6.0.4",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/glob/-/glob-6.0.4.tgz",
                     "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
                     "dev": true,
                     "requires": {
@@ -523,7 +500,7 @@
                 },
                 "rimraf": {
                     "version": "2.4.5",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/rimraf/-/rimraf-2.4.5.tgz",
                     "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
                     "dev": true,
                     "requires": {
@@ -534,13 +511,13 @@
         },
         "ncp": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/ncp/-/ncp-2.0.0.tgz",
             "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
             "dev": true
         },
         "node-int64": {
             "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/node-int64/-/node-int64-0.4.0.tgz",
             "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
             "dev": true
         },
@@ -559,38 +536,30 @@
         },
         "pend": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/pend/-/pend-1.2.0.tgz",
             "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
         },
         "process-nextick-args": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
         },
         "rc": {
             "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
             "dev": true,
             "requires": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
                 "minimist": "^1.2.0",
                 "strip-json-comments": "~2.0.1"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                }
             }
         },
         "readable-stream": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "version": "2.3.7",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
             "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -603,47 +572,47 @@
             "dependencies": {
                 "safe-buffer": {
                     "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                    "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
                 }
             }
         },
         "rfc-3986": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/rfc-3986/-/rfc-3986-1.0.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/rfc-3986/-/rfc-3986-1.0.1.tgz",
             "integrity": "sha1-7uuINC+tvoAnwPNq2pIaE+b5YgY=",
             "dev": true
         },
         "rfdc": {
             "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.4.tgz",
-            "integrity": "sha512-5C9HXdzK8EAqN7JDif30jqsBzavB7wLpaubisuQIGHWf2gUXSpzy6ArX/+Da8RjFpagWsCn+pIgxTMAmKw9Zug==",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/rfdc/-/rfdc-1.1.4.tgz",
+            "integrity": "sha1-unLME2egzNnPgahws7WL060H+MI=",
             "dev": true
         },
         "rimraf": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+            "version": "2.7.1",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/rimraf/-/rimraf-2.7.1.tgz",
+            "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
             "requires": {
                 "glob": "^7.1.3"
             }
         },
         "safe-buffer": {
             "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-            "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/safe-buffer/-/safe-buffer-5.2.0.tgz",
+            "integrity": "sha1-t02uxJsRSPiMZLaNSbHoFcHy9Rk=",
             "dev": true
         },
         "semver": {
             "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
             "dev": true
         },
         "streamroller": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.0.tgz",
-            "integrity": "sha512-0CTjQK2fHo/qAUMoCd/J5BvxqoPyAQFaMorv2Z4cxjLYPYRn0Q9PG8Z7LHvyK2mDHSpeS9R7AvMr0vSI/Mq0HA==",
+            "version": "2.2.3",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/streamroller/-/streamroller-2.2.3.tgz",
+            "integrity": "sha1-uVyfrUTi6JAF0kIUFIaztJYsLSg=",
             "dev": true,
             "requires": {
                 "date-format": "^2.1.0",
@@ -653,8 +622,8 @@
             "dependencies": {
                 "debug": {
                     "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
                     "dev": true,
                     "requires": {
                         "ms": "^2.1.1"
@@ -664,29 +633,29 @@
         },
         "string_decoder": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
             "requires": {
                 "safe-buffer": "~5.1.0"
             },
             "dependencies": {
                 "safe-buffer": {
                     "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                    "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
                 }
             }
         },
         "strip-json-comments": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
             "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
             "dev": true
         },
         "tar": {
             "version": "4.4.13",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-            "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/tar/-/tar-4.4.13.tgz",
+            "integrity": "sha1-Q7NkvFKIjVVSmGN7ENYHkCVKtSU=",
             "dev": true,
             "requires": {
                 "chownr": "^1.1.1",
@@ -699,77 +668,76 @@
             }
         },
         "tslib": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-            "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+            "version": "1.11.1",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/tslib/-/tslib-1.11.1.tgz",
+            "integrity": "sha1-6xXRKIJ/vuKEFUnhcfRe0zisfjU=",
             "dev": true
         },
         "tunnel": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-            "dev": true
+            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
         },
         "typedarray": {
             "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/typedarray/-/typedarray-0.0.6.tgz",
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
         },
         "typescript": {
-            "version": "3.6.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
-            "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==",
+            "version": "3.8.3",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/typescript/-/typescript-3.8.3.tgz",
+            "integrity": "sha1-QJ64VE6gM1cRIFhp7EWKsQnuEGE=",
             "dev": true
         },
         "universalify": {
             "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
             "dev": true
         },
         "util-deprecate": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "uuid": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-            "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+            "version": "3.4.0",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/uuid/-/uuid-3.4.0.tgz",
+            "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
             "dev": true
         },
         "vscode-jsonrpc": {
-            "version": "4.1.0-next.3",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.1.0-next.3.tgz",
-            "integrity": "sha512-Z6oxBiMks2+UADV1QHXVooSakjyhI+eHTnXzDyVvVMmegvSfkXk2w6mPEdSkaNHFBdtWW7n20H1yw2nA3A17mg==",
+            "version": "5.0.1",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
+            "integrity": "sha1-m6ucMw2J9D/IwehwK1w24FigF5Q=",
             "dev": true
         },
         "vscode-languageserver-protocol": {
-            "version": "3.15.0-next.6",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.0-next.6.tgz",
-            "integrity": "sha512-/yDpYlWyNs26mM23mT73xmOFsh1iRfgZfBdHmfAxwDKwpQKLoOSqVidtYfxlK/pD3IEKGcAVnT4WXTsguxxAMQ==",
+            "version": "3.15.3",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz",
+            "integrity": "sha1-P6mgcC10LPeIPLYYKmIS/NCh2Ls=",
             "dev": true,
             "requires": {
-                "vscode-jsonrpc": "^4.1.0-next.2",
-                "vscode-languageserver-types": "^3.15.0-next.2"
+                "vscode-jsonrpc": "^5.0.1",
+                "vscode-languageserver-types": "3.15.1"
             }
         },
         "vscode-languageserver-types": {
-            "version": "3.15.0-next.2",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.0-next.2.tgz",
-            "integrity": "sha512-2JkrMWWUi2rlVLSo9OFR2PIGUzdiowEM8NgNYiwLKnXTjpwpjjIrJbNNxDik7Rv4oo9KtikcFQZKXbrKilL/MQ==",
+            "version": "3.15.1",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
+            "integrity": "sha1-F75x140vYjbUFPAAHOHvTSPmtt4=",
             "dev": true
         },
         "vscode-uri": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.0.3.tgz",
-            "integrity": "sha512-4D3DI3F4uRy09WNtDGD93H9q034OHImxiIcSq664Hq1Y1AScehlP3qqZyTkX/RWxeu0MRMHGkrxYqm2qlDF/aw==",
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/vscode-uri/-/vscode-uri-2.1.1.tgz",
+            "integrity": "sha1-WqGAM5G2690X0Ef1E2XPYsOPbpA=",
             "dev": true
         },
         "which": {
             "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/which/-/which-1.3.1.tgz",
+            "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
             "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
@@ -782,16 +750,17 @@
         },
         "yallist": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
             "dev": true
         },
         "yauzl": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-            "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+            "version": "2.10.0",
+            "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/yauzl/-/yauzl-2.10.0.tgz",
+            "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
             "requires": {
-                "fd-slicer": "~1.0.1"
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.1.0"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "url": "https://github.com/yatli/coc-powershell"
     },
     "engines": {
-        "coc": ">=0.0.71"
+        "coc": ">=0.0.77"
     },
     "keywords": [
         "pwsh",
@@ -317,8 +317,9 @@
         "coc-utils": "0.0.12"
     },
     "devDependencies": {
-        "@types/node": "^10.3.3",
-        "typescript": "^3.5.2",
-        "coc.nvim": "^0.0.74"
+        "@types/follow-redirects": "^1.8.0",
+        "@types/node": "~10.17.19",
+        "typescript": "~3.8.3",
+        "coc.nvim": "~0.0.77"
     }
 }

--- a/src/client/platform.ts
+++ b/src/client/platform.ts
@@ -2,189 +2,504 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import fs = require("fs");
-import path = require("path");
-import process = require("process");
-import Settings = require("./settings");
-import { IPlatformDetails, OperatingSystem } from 'coc-utils'
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import * as process from "process";
+import { IPowerShellAdditionalExePathSettings } from "./settings";
 
-const linuxExePath        = "/usr/bin/pwsh";
-const linuxPreviewExePath = "/usr/bin/pwsh-preview";
+const WindowsPowerShell64BitLabel = "Windows PowerShell (x64)";
+const WindowsPowerShell32BitLabel = "Windows PowerShell (x86)";
 
-const snapExePath         = "/snap/bin/pwsh";
-const snapPreviewExePath  = "/snap/bin/pwsh-preview";
+const LinuxExePath        = "/usr/bin/pwsh";
+const LinuxPreviewExePath = "/usr/bin/pwsh-preview";
 
-const macOSExePath        = "/usr/local/bin/pwsh";
-const macOSPreviewExePath = "/usr/local/bin/pwsh-preview";
+const SnapExePath         = "/snap/bin/pwsh";
+const SnapPreviewExePath  = "/snap/bin/pwsh-preview";
+
+const MacOSExePath        = "/usr/local/bin/pwsh";
+const MacOSPreviewExePath = "/usr/local/bin/pwsh-preview";
+
+export enum OperatingSystem {
+    Unknown,
+    Windows,
+    MacOS,
+    Linux,
+}
+
+export interface IPlatformDetails {
+    operatingSystem: OperatingSystem;
+    isOS64Bit: boolean;
+    isProcess64Bit: boolean;
+}
 
 export interface IPowerShellExeDetails {
-    versionName: string;
-    exePath: string;
+    readonly displayName: string;
+    readonly exePath: string;
+}
+
+export function getPlatformDetails(): IPlatformDetails {
+    let operatingSystem = OperatingSystem.Unknown;
+
+    if (process.platform === "win32") {
+        operatingSystem = OperatingSystem.Windows;
+    } else if (process.platform === "darwin") {
+        operatingSystem = OperatingSystem.MacOS;
+    } else if (process.platform === "linux") {
+        operatingSystem = OperatingSystem.Linux;
+    }
+
+    const isProcess64Bit = process.arch === "x64";
+
+    return {
+        operatingSystem,
+        isOS64Bit: isProcess64Bit || process.env.hasOwnProperty("PROCESSOR_ARCHITEW6432"),
+        isProcess64Bit,
+    };
 }
 
 /**
- * Gets the default instance of PowerShell for the specified platform.
- * On Windows, the default version of PowerShell is "Windows PowerShell".
- * @param platformDetails Specifies information about the platform - primarily the operating system.
- * @param use32Bit On Windows, this boolean determines whether the 32-bit version of Windows PowerShell is returned.
- * @returns A string containing the path of the default version of PowerShell.
+ * Class to lazily find installed PowerShell executables on a machine.
+ * When given a list of additional PowerShell executables,
+ * this will also surface those at the end of the list.
  */
-export function getDefaultPowerShellPath(
-    platformDetails: IPlatformDetails,
-    use32Bit: boolean = false): string | null {
+export class PowerShellExeFinder {
+    // This is required, since parseInt("7-preview") will return 7.
+    private static IntRegex: RegExp = /^\d+$/;
 
-    let powerShellExePath;
+    private static PwshMsixRegex: RegExp = /^Microsoft.PowerShell_.*/;
 
-    // Find the path to powershell.exe based on the current platform
-    // and the user's desire to run the x86 version of PowerShell
-    if (platformDetails.operatingSystem === OperatingSystem.Windows) {
-        if (use32Bit) {
-            powerShellExePath =
-                platformDetails.isOS64Bit && platformDetails.isProcess64Bit
-                    ? SysWow64PowerShellPath
-                    : System32PowerShellPath;
-        } else {
-            powerShellExePath =
-                !platformDetails.isOS64Bit || platformDetails.isProcess64Bit
-                    ? System32PowerShellPath
-                    : SysnativePowerShellPath;
+    private static PwshPreviewMsixRegex: RegExp = /^Microsoft.PowerShellPreview_.*/;
+
+    // The platform details descriptor for the platform we're on
+    private readonly platformDetails: IPlatformDetails;
+
+    // Additional configured PowerShells
+    private readonly additionalPSExeSettings: Iterable<IPowerShellAdditionalExePathSettings>;
+
+    private winPS: IPossiblePowerShellExe;
+
+    private alternateBitnessWinPS: IPossiblePowerShellExe;
+
+    /**
+     * Create a new PowerShellFinder object to discover PowerShell installations.
+     * @param platformDetails Information about the machine we are running on.
+     * @param additionalPowerShellExes Additional PowerShell installations as configured in the settings.
+     */
+    constructor(
+        platformDetails?: IPlatformDetails,
+        additionalPowerShellExes?: Iterable<IPowerShellAdditionalExePathSettings>) {
+
+        this.platformDetails = platformDetails || getPlatformDetails();
+        this.additionalPSExeSettings = additionalPowerShellExes || [];
+    }
+
+    /**
+     * Returns the first available PowerShell executable found in the search order.
+     */
+    public getFirstAvailablePowerShellInstallation(): IPowerShellExeDetails {
+        for (const pwsh of this.enumeratePowerShellInstallations()) {
+            return pwsh;
         }
-    } else if (platformDetails.operatingSystem === OperatingSystem.MacOS) {
-        // Always default to the stable version of PowerShell (if installed) but handle case of only Preview installed
-        powerShellExePath = macOSExePath;
-        if (!fs.existsSync(macOSExePath) && fs.existsSync(macOSPreviewExePath)) {
-            powerShellExePath = macOSPreviewExePath;
+
+        throw new Error("No available PowerShell executables on this machine.");
+    }
+
+    /**
+     * Get an array of all PowerShell executables found when searching for PowerShell installations.
+     */
+    public getAllAvailablePowerShellInstallations(): IPowerShellExeDetails[] {
+        return Array.from(this.enumeratePowerShellInstallations());
+    }
+
+    /**
+     * Fixes PowerShell paths when Windows PowerShell is set to the non-native bitness.
+     * @param configuredPowerShellPath the PowerShell path configured by the user.
+     */
+    public fixWindowsPowerShellPath(configuredPowerShellPath: string): string {
+        const altWinPS = this.findWinPS({ useAlternateBitness: true });
+
+        if (!altWinPS) {
+            return configuredPowerShellPath;
         }
-    } else if (platformDetails.operatingSystem === OperatingSystem.Linux) {
-        // Always default to the stable version of PowerShell (if installed) but handle case of only Preview installed
-        // as well as the Snaps case - https://snapcraft.io/
-        powerShellExePath = linuxExePath;
-        if (!fs.existsSync(linuxExePath) && fs.existsSync(linuxPreviewExePath)) {
-            powerShellExePath = linuxPreviewExePath;
-        } else if (fs.existsSync(snapExePath)) {
-            powerShellExePath = snapExePath;
-        } else if (fs.existsSync(snapPreviewExePath)) {
-            powerShellExePath = snapPreviewExePath;
+
+        const lowerAltWinPSPath = altWinPS.exePath.toLocaleLowerCase();
+        const lowerConfiguredPath = configuredPowerShellPath.toLocaleLowerCase();
+
+        if (lowerConfiguredPath === lowerAltWinPSPath) {
+            return this.findWinPS().exePath;
+        }
+
+        return configuredPowerShellPath;
+    }
+
+    /**
+     * Iterates through PowerShell installations on the machine according
+     * to configuration passed in through the constructor.
+     * PowerShell items returned by this object are verified
+     * to exist on the filesystem.
+     */
+    public *enumeratePowerShellInstallations(): Iterable<IPowerShellExeDetails> {
+        // Get the default PowerShell installations first
+        for (const defaultPwsh of this.enumerateDefaultPowerShellInstallations()) {
+            if (defaultPwsh && defaultPwsh.exists()) {
+                yield defaultPwsh;
+            }
+        }
+
+        // Also show any additionally configured PowerShells
+        // These may be duplicates of the default installations, but given a different name.
+        for (const additionalPwsh of this.enumerateAdditionalPowerShellInstallations()) {
+            if (additionalPwsh && additionalPwsh.exists()) {
+                yield additionalPwsh;
+            }
         }
     }
 
-    return powerShellExePath;
+    /**
+     * Iterates through all the possible well-known PowerShell installations on a machine.
+     * Returned values may not exist, but come with an .exists property
+     * which will check whether the executable exists.
+     */
+    private *enumerateDefaultPowerShellInstallations(): Iterable<IPossiblePowerShellExe> {
+        // Find PSCore stable first
+        yield this.findPSCoreStable();
+
+        switch (this.platformDetails.operatingSystem) {
+            case OperatingSystem.Linux:
+                // On Linux, find the snap
+                yield this.findPSCoreStableSnap();
+                break;
+
+            case OperatingSystem.Windows:
+                // Windows may have a 32-bit pwsh.exe
+                yield this.findPSCoreWindowsInstallation({ useAlternateBitness: true });
+
+                // Also look for the MSIX/UWP installation
+                yield this.findPSCoreMsix();
+
+                break;
+        }
+
+        // Look for the .NET global tool
+        // Some older versions of PowerShell have a bug in this where startup will fail,
+        // but this is fixed in newer versions
+        yield this.findPSCoreDotnetGlobalTool();
+
+        // Look for PSCore preview
+        yield this.findPSCorePreview();
+
+        switch (this.platformDetails.operatingSystem) {
+            // On Linux, there might be a preview snap
+            case OperatingSystem.Linux:
+                yield this.findPSCorePreviewSnap();
+                break;
+
+            case OperatingSystem.Windows:
+                // Find a preview MSIX
+                yield this.findPSCoreMsix({ findPreview: true });
+
+                // Look for pwsh-preview with the opposite bitness
+                yield this.findPSCoreWindowsInstallation({ useAlternateBitness: true, findPreview: true });
+
+                // Finally, get Windows PowerShell
+
+                // Get the natural Windows PowerShell for the process bitness
+                yield this.findWinPS();
+
+                // Get the alternate bitness Windows PowerShell
+                yield this.findWinPS({ useAlternateBitness: true });
+
+                break;
+        }
+    }
+
+    /**
+     * Iterates through the configured additonal PowerShell executable locations,
+     * without checking for their existence.
+     */
+    private *enumerateAdditionalPowerShellInstallations(): Iterable<IPossiblePowerShellExe> {
+        for (const additionalPwshSetting of this.additionalPSExeSettings) {
+            yield new PossiblePowerShellExe(additionalPwshSetting.exePath, additionalPwshSetting.versionName);
+        }
+    }
+
+    private findPSCoreStable(): IPossiblePowerShellExe {
+        switch (this.platformDetails.operatingSystem) {
+            case OperatingSystem.Linux:
+                return new PossiblePowerShellExe(LinuxExePath, "PowerShell");
+
+            case OperatingSystem.MacOS:
+                return new PossiblePowerShellExe(MacOSExePath, "PowerShell");
+
+            case OperatingSystem.Windows:
+                return this.findPSCoreWindowsInstallation();
+            
+            case OperatingSystem.Unknown:
+                throw new Error("Unable to detect operating system");
+        }
+    }
+
+    private findPSCorePreview(): IPossiblePowerShellExe {
+        switch (this.platformDetails.operatingSystem) {
+            case OperatingSystem.Linux:
+                return new PossiblePowerShellExe(LinuxPreviewExePath, "PowerShell Preview");
+
+            case OperatingSystem.MacOS:
+                return new PossiblePowerShellExe(MacOSPreviewExePath, "PowerShell Preview");
+
+            case OperatingSystem.Windows:
+                return this.findPSCoreWindowsInstallation({ findPreview: true });
+            
+            case OperatingSystem.Unknown:
+                throw new Error("Unable to detect operating system");
+        }
+    }
+
+    private findPSCoreDotnetGlobalTool(): IPossiblePowerShellExe {
+        const exeName: string = this.platformDetails.operatingSystem === OperatingSystem.Windows
+            ? "pwsh.exe"
+            : "pwsh";
+
+        const dotnetGlobalToolExePath: string = path.join(os.homedir(), ".dotnet", "tools", exeName);
+
+        return new PossiblePowerShellExe(dotnetGlobalToolExePath, ".NET Core PowerShell Global Tool");
+    }
+
+    private findPSCoreMsix({ findPreview }: { findPreview?: boolean } = {}): IPossiblePowerShellExe {
+        // We can't proceed if there's no LOCALAPPDATA path
+        if (!process.env.LOCALAPPDATA) {
+            return null;
+        }
+
+        // Find the base directory for MSIX application exe shortcuts
+        const msixAppDir = path.join(process.env.LOCALAPPDATA, "Microsoft", "WindowsApps");
+
+        if (!fs.existsSync(msixAppDir)) {
+            return null;
+        }
+
+        // Define whether we're looking for the preview or the stable
+        const { pwshMsixDirRegex, pwshMsixName } = findPreview
+            ? { pwshMsixDirRegex: PowerShellExeFinder.PwshPreviewMsixRegex, pwshMsixName: "PowerShell Preview (Store)" }
+            : { pwshMsixDirRegex: PowerShellExeFinder.PwshMsixRegex, pwshMsixName: "PowerShell (Store)" };
+
+        // We should find only one such application, so return on the first one
+        for (const subdir of fs.readdirSync(msixAppDir)) {
+            if (pwshMsixDirRegex.test(subdir)) {
+                const pwshMsixPath = path.join(msixAppDir, subdir, "pwsh.exe");
+                return new PossiblePowerShellExe(pwshMsixPath, pwshMsixName);
+            }
+        }
+
+        // If we find nothing, return null
+        return null;
+    }
+
+    private findPSCoreStableSnap(): IPossiblePowerShellExe {
+        return new PossiblePowerShellExe(SnapExePath, "PowerShell Snap");
+    }
+
+    private findPSCorePreviewSnap(): IPossiblePowerShellExe {
+        return new PossiblePowerShellExe(SnapPreviewExePath, "PowerShell Preview Snap");
+    }
+
+    private findPSCoreWindowsInstallation(
+        { useAlternateBitness = false, findPreview = false }:
+            { useAlternateBitness?: boolean; findPreview?: boolean } = {}): IPossiblePowerShellExe {
+
+        const programFilesPath: string = this.getProgramFilesPath({ useAlternateBitness });
+
+        if (!programFilesPath) {
+            return null;
+        }
+
+        const powerShellInstallBaseDir = path.join(programFilesPath, "PowerShell");
+
+        // Ensure the base directory exists
+        if (!(fs.existsSync(powerShellInstallBaseDir) && fs.lstatSync(powerShellInstallBaseDir).isDirectory())) {
+            return null;
+        }
+
+        let highestSeenVersion: number = -1;
+        let pwshExePath: string = null;
+        for (const item of fs.readdirSync(powerShellInstallBaseDir)) {
+
+            let currentVersion: number = -1;
+            if (findPreview) {
+                // We are looking for something like "7-preview"
+
+                // Preview dirs all have dashes in them
+                const dashIndex = item.indexOf("-");
+                if (dashIndex < 0) {
+                    continue;
+                }
+
+                // Verify that the part before the dash is an integer
+                const intPart: string = item.substring(0, dashIndex);
+                if (!PowerShellExeFinder.IntRegex.test(intPart)) {
+                    continue;
+                }
+
+                // Verify that the part after the dash is "preview"
+                if (item.substring(dashIndex + 1) !== "preview") {
+                    continue;
+                }
+
+                currentVersion = parseInt(intPart, 10);
+            } else {
+                // Search for a directory like "6" or "7"
+                if (!PowerShellExeFinder.IntRegex.test(item)) {
+                    continue;
+                }
+
+                currentVersion = parseInt(item, 10);
+            }
+
+            // Ensure we haven't already seen a higher version
+            if (currentVersion <= highestSeenVersion) {
+                continue;
+            }
+
+            // Now look for the file
+            const exePath = path.join(powerShellInstallBaseDir, item, "pwsh.exe");
+            if (!fs.existsSync(exePath)) {
+                continue;
+            }
+
+            pwshExePath = exePath;
+            highestSeenVersion = currentVersion;
+        }
+
+        if (!pwshExePath) {
+            return null;
+        }
+
+        const bitness: string = programFilesPath.includes("x86")
+            ? "(x86)"
+            : "(x64)";
+
+        const preview: string = findPreview ? " Preview" : "";
+
+        return new PossiblePowerShellExe(pwshExePath, `PowerShell${preview} ${bitness}`);
+    }
+
+    private findWinPS({ useAlternateBitness = false }: { useAlternateBitness?: boolean } = {}): IPossiblePowerShellExe {
+
+        // 32-bit OSes only have one WinPS on them
+        if (!this.platformDetails.isOS64Bit && useAlternateBitness) {
+            return null;
+        }
+
+        let winPS = useAlternateBitness ? this.alternateBitnessWinPS : this.winPS;
+        if (winPS === undefined) {
+            const systemFolderPath: string = this.getSystem32Path({ useAlternateBitness });
+
+            const winPSPath = path.join(systemFolderPath, "WindowsPowerShell", "v1.0", "powershell.exe");
+
+            let displayName: string;
+            if (this.platformDetails.isProcess64Bit) {
+                displayName = useAlternateBitness
+                    ? WindowsPowerShell32BitLabel
+                    : WindowsPowerShell64BitLabel;
+            } else if (this.platformDetails.isOS64Bit) {
+                displayName = useAlternateBitness
+                    ? WindowsPowerShell64BitLabel
+                    : WindowsPowerShell32BitLabel;
+            } else {
+                displayName = WindowsPowerShell32BitLabel;
+            }
+
+            winPS = new PossiblePowerShellExe(winPSPath, displayName, { knownToExist: true });
+
+            if (useAlternateBitness) {
+                this.alternateBitnessWinPS = winPS;
+            } else {
+                this.winPS = winPS;
+            }
+        }
+
+        return winPS;
+    }
+
+    private getProgramFilesPath(
+        { useAlternateBitness = false }: { useAlternateBitness?: boolean } = {}): string | null {
+
+        if (!useAlternateBitness) {
+            // Just use the native system bitness
+            return process.env.ProgramFiles;
+        }
+
+        // We might be a 64-bit process looking for 32-bit program files
+        if (this.platformDetails.isProcess64Bit) {
+            return process.env["ProgramFiles(x86)"];
+        }
+
+        // We might be a 32-bit process looking for 64-bit program files
+        if (this.platformDetails.isOS64Bit) {
+            return process.env.ProgramW6432;
+        }
+
+        // We're a 32-bit process on 32-bit Windows, there is no other Program Files dir
+        return null;
+    }
+
+    private getSystem32Path({ useAlternateBitness = false }: { useAlternateBitness?: boolean } = {}): string | null {
+        const windir: string = process.env.windir;
+
+        if (!useAlternateBitness) {
+            // Just use the native system bitness
+            return path.join(windir, "System32");
+        }
+
+        // We might be a 64-bit process looking for 32-bit system32
+        if (this.platformDetails.isProcess64Bit) {
+            return path.join(windir, "SysWOW64");
+        }
+
+        // We might be a 32-bit process looking for 64-bit system32
+        if (this.platformDetails.isOS64Bit) {
+            return path.join(windir, "Sysnative");
+        }
+
+        // We're on a 32-bit Windows, so no alternate bitness
+        return null;
+    }
 }
 
 export function getWindowsSystemPowerShellPath(systemFolderName: string) {
-    return `${process.env.windir}\\${systemFolderName}\\WindowsPowerShell\\v1.0\\powershell.exe`;
+    return path.join(
+        process.env.windir,
+        systemFolderName,
+        "WindowsPowerShell",
+        "v1.0",
+        "powershell.exe");
 }
 
-export const System32PowerShellPath = getWindowsSystemPowerShellPath("System32");
-export const SysnativePowerShellPath = getWindowsSystemPowerShellPath("Sysnative");
-export const SysWow64PowerShellPath = getWindowsSystemPowerShellPath("SysWow64");
-
-export const WindowsPowerShell64BitLabel = "Windows PowerShell (x64)";
-export const WindowsPowerShell32BitLabel = "Windows PowerShell (x86)";
-
-const powerShell64BitPathOn32Bit = SysnativePowerShellPath.toLocaleLowerCase();
-const powerShell32BitPathOn64Bit = SysWow64PowerShellPath.toLocaleLowerCase();
-
-export function fixWindowsPowerShellPath(powerShellExePath: string, platformDetails: IPlatformDetails): string {
-    const lowerCasedPath = powerShellExePath.toLocaleLowerCase();
-
-    if ((platformDetails.isProcess64Bit && (lowerCasedPath === powerShell64BitPathOn32Bit)) ||
-        (!platformDetails.isProcess64Bit && (lowerCasedPath === powerShell32BitPathOn64Bit))) {
-            return System32PowerShellPath;
-    }
-
-    // If the path doesn't need to be fixed, return the original
-    return powerShellExePath;
+interface IPossiblePowerShellExe extends IPowerShellExeDetails {
+    exists(): boolean;
 }
 
-/**
- * Gets a list of all available PowerShell instance on the specified platform.
- * @param platformDetails Specifies information about the platform - primarily the operating system.
- * @param sessionSettings Specifies the user/workspace settings. Additional PowerShell exe paths loaded from settings.
- * @returns An array of IPowerShellExeDetails objects with the PowerShell name & exe path for each instance found.
- */
-export function getAvailablePowerShellExes(
-    platformDetails: IPlatformDetails,
-    sessionSettings: Settings.ISettings | undefined): IPowerShellExeDetails[] {
+class PossiblePowerShellExe implements IPossiblePowerShellExe {
+    public readonly exePath: string;
+    public readonly displayName: string;
 
-    let paths: IPowerShellExeDetails[] = [];
+    private knownToExist: boolean;
 
-    if (platformDetails.operatingSystem === OperatingSystem.Windows) {
-        if (platformDetails.isProcess64Bit) {
-            paths.push({
-                versionName: WindowsPowerShell64BitLabel,
-                exePath: System32PowerShellPath,
-            });
+    constructor(
+        pathToExe: string,
+        installationName: string,
+        { knownToExist = false }: { knownToExist?: boolean } = {}) {
 
-            paths.push({
-                versionName: WindowsPowerShell32BitLabel,
-                exePath: SysWow64PowerShellPath,
-            });
-        } else {
-            if (platformDetails.isOS64Bit) {
-                paths.push({
-                    versionName: WindowsPowerShell64BitLabel,
-                    exePath: SysnativePowerShellPath,
-                });
-            }
-
-            paths.push({
-                versionName: WindowsPowerShell32BitLabel,
-                exePath: System32PowerShellPath,
-            });
-        }
-
-        const psCoreInstallPath =
-            (!platformDetails.isProcess64Bit ? process.env.ProgramW6432 : process.env.ProgramFiles) + "\\PowerShell";
-
-        if (fs.existsSync(psCoreInstallPath)) {
-            const arch = platformDetails.isProcess64Bit ? "(x64)" : "(x86)";
-            const psCorePaths =
-                fs.readdirSync(psCoreInstallPath)
-                .map((item) => path.join(psCoreInstallPath, item))
-                .filter((item) => {
-                    const exePath = path.join(item, "pwsh.exe");
-                    return fs.lstatSync(item).isDirectory() && fs.existsSync(exePath);
-                })
-                .map((item) => ({
-                    versionName: `PowerShell Core ${path.parse(item).base} ${arch}`,
-                    exePath: path.join(item, "pwsh.exe"),
-                }));
-
-            if (psCorePaths) {
-                paths = paths.concat(psCorePaths);
-            }
-        }
-    } else {
-        // Handle Linux and macOS case
-        let exePaths: string[];
-
-        if (platformDetails.operatingSystem === OperatingSystem.Linux) {
-            exePaths = [ linuxExePath, snapExePath, linuxPreviewExePath, snapPreviewExePath ];
-        } else {
-            exePaths = [ macOSExePath, macOSPreviewExePath ];
-        }
-
-        exePaths.forEach((exePath) => {
-            if (fs.existsSync(exePath)) {
-                paths.push({
-                    versionName: "PowerShell Core" + (/-preview/.test(exePath) ? " Preview" : ""),
-                    exePath,
-                });
-            }
-        });
+        this.exePath = pathToExe;
+        this.displayName = installationName;
+        this.knownToExist = knownToExist || undefined;
     }
 
-    // When unit testing, we don't have session settings available to test, so skip reading this setting
-    if (sessionSettings) {
-        // Add additional PowerShell paths as configured in settings
-        for (const additionalPowerShellExePath of sessionSettings.powerShellAdditionalExePaths) {
-            paths.push({
-                versionName: additionalPowerShellExePath.versionName,
-                exePath: additionalPowerShellExePath.exePath,
-            });
+    public exists(): boolean {
+        if (this.knownToExist === undefined) {
+            this.knownToExist = fs.existsSync(this.exePath);
         }
+        return this.knownToExist;
     }
-
-    return paths;
 }


### PR DESCRIPTION
This grabs the implementation from `vscode-powershell` which has a more fully featured way of discovering what PowerShell exe's are installed on the system.

This also supports the same setting as vscode-powershell:

```json
"powershell.powerShellAdditionalExePaths": [
        {
            "exePath": "/Users/tyleonha/.powershell-daily/pwsh",
            "versionName": "PowerShell Daily"
        },
        {
            "exePath": "/Users/tyleonha/Code/PowerShell/PowerShell/src/powershell-unix/bin/Debug/netcoreapp3.1/osx-x64/publish/pwsh",
            "versionName": "PowerShell Local Build"
        }
],

"powershell.powerShellDefaultVersion": "PowerShell Daily"
```

I'd say you don't have to worry about reviewing `src/client/platform.ts` since that was already battle tested in vscode-powershell but review everything else :) 

This also means `coc-powershell` will bring in PSES 2.1.0 which includes a ton of perf improvements and PSReadLine support in the integrated console.